### PR TITLE
Fix test cases.

### DIFF
--- a/src/main/java/movies/spring/data/neo4j/repositories/MovieRepository.java
+++ b/src/main/java/movies/spring/data/neo4j/repositories/MovieRepository.java
@@ -17,7 +17,7 @@ public interface MovieRepository extends PagingAndSortingRepository<Movie, Long>
 
 	Movie findByTitle(@Param("title") String title);
 
-	Collection<Movie> findByTitleLike(@Param("title") String title);
+	Collection<Movie> findByTitleContaining(String title);
 
 	@Query("MATCH (m:Movie)<-[r:ACTED_IN]-(a:Person) RETURN m,r,a LIMIT {limit}")
 	Collection<Movie> graph(@Param("limit") int limit);

--- a/src/test/java/movies/spring/data/neo4j/repositories/MovieRepositoryTest.java
+++ b/src/test/java/movies/spring/data/neo4j/repositories/MovieRepositoryTest.java
@@ -67,7 +67,7 @@ public class MovieRepositoryTest {
 	@Test
 	public void testFindByTitle() {
 
-		String title = "*The Matrix*";
+		String title = "The Matrix";
 		Movie result = instance.findByTitle(title);
 		assertNotNull(result);
 		assertEquals(1999, result.getReleased());
@@ -79,7 +79,7 @@ public class MovieRepositoryTest {
 	@Test
 	public void testFindByTitleContaining() {
 		String title = "Matrix";
-		Collection<Movie> result = instance.findByTitleLike(title);
+		Collection<Movie> result = instance.findByTitleContaining(title);
 		assertNotNull(result);
 		assertEquals(1, result.size());
 	}


### PR DESCRIPTION
testFindByTitle removes "*" characters, which are only required with findByPropertyLIke
testFindByTitleContaining uses the now supported Part.Type 